### PR TITLE
Update requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -40,4 +40,4 @@ dependencies:
   - tensorflow==1.4.1
   - tensorflow-tensorboard==0.4.0
   - werkzeug==0.14.1
-  - youtube-dl==2018.1.21
+  - youtube-dl==2021.6.6


### PR DESCRIPTION
Older version of youtube-dl was spitting 404 errors when downloading videos. Version 2021.6.6 gives no such issues.